### PR TITLE
Fixing crash in TFC::Serialization and TFC::Components

### DIFF
--- a/TizenFundamentalClasses/inc/TFC/Components/ContextMenu.h
+++ b/TizenFundamentalClasses/inc/TFC/Components/ContextMenu.h
@@ -97,6 +97,21 @@ public:
 	void SetMenu(const std::vector<MenuItem*>& listOfMenus);
 
 	/**
+	 * Method to know if ContextMenu is showed.
+	 */
+	bool IsShow();
+
+	/**
+	 * Method to manually show ContextMenu.
+	 */
+	void ShowMenu();
+
+	/**
+	 * Method to manually hide ContextMenu.
+	 */
+	void HideMenu();
+
+	/**
 	 * Destructor of ContextMenu.
 	 */
 	virtual ~ContextMenu();
@@ -133,8 +148,6 @@ private:
 
 	void OnContextMenuButtonClicked(Evas_Object* obj, void* eventData);
 	void OnContextMenuDismissed(Evas_Object* obj, void* eventData);
-	void ShowMenu();
-	void HideMenu();
 
 	void RaiseOnClickEvent(MenuItem* menuItemRef);
 

--- a/TizenFundamentalClasses/inc/TFC/Components/Field.h
+++ b/TizenFundamentalClasses/inc/TFC/Components/Field.h
@@ -105,6 +105,15 @@ public:
 	void SetCursorAtEnd();
 
 	/**
+	 * Set the maximum number of characters allowed to be input.
+	 *
+	 * @param int number of characters allowed.
+	 */
+	void SetCharLimit(int const& limit);
+	int	GetCharLimit() const;
+
+
+	/**
 	 * Event that will be triggered when user input return key.
 	 */
 	EvasSmartEvent eventReturnKeyClick;
@@ -121,6 +130,8 @@ private:
 
 	bool multiline;
 	bool bottomBorder;
+
+	Elm_Entry_Filter_Limit_Size limit_size;
 protected:
 	/**
 	 * Method overriden from ComponentBase, creates the UI elements of the component.

--- a/TizenFundamentalClasses/inc/TFC/Components/TabbarViewController.h
+++ b/TizenFundamentalClasses/inc/TFC/Components/TabbarViewController.h
@@ -51,6 +51,7 @@ class LIBAPI TabbarViewController:
 {
 public:
 	TabbarViewController(TFC::Framework::ControllerManager* m, char const* controllerName);
+	int GetCurrentTab();
 protected:
 	void AddTab(std::string text, Framework::ControllerBase& controller);
 	virtual Evas_Object* CreateView(Evas_Object* root) final;

--- a/TizenFundamentalClasses/inc/TFC/Infrastructures/ScheduledEvent.h
+++ b/TizenFundamentalClasses/inc/TFC/Infrastructures/ScheduledEvent.h
@@ -26,15 +26,20 @@
 #define TFC_INFRASTRUCTURES_SCHEDULEDEVENT_H_
 
 #include "TFC/Infrastructures/ScheduledTask.h"
+#include <functional>
 
 namespace TFC {
 namespace Infrastructures {
 
 class LIBAPI ScheduledEvent : public ScheduledTask, public EventEmitterClass<ScheduledEvent>
 {
+private:
+	void* data;
 protected:
 	virtual void Run();
 public:
+	ScheduledEvent();
+	void SetData(void* data);
 	Event<void*> eventRunTask;
 };
 

--- a/TizenFundamentalClasses/inc/TFC/ServiceModel/GDBusEndpoint.h
+++ b/TizenFundamentalClasses/inc/TFC/ServiceModel/GDBusEndpoint.h
@@ -514,7 +514,9 @@ struct GDBusSignatureFiller<std::vector<TVectorType>, TArgs...>
 {
 	static void GetSignature(std::vector<std::string>& param)
 	{
-		param.push_back("a" + GDBusCompositeSignatureBuilder<typename TFC::Serialization::TypeSerializationInfoSelector<TVectorType>::Type>::GetSignature());
+		std::string ret { "a" };
+		ret += GDBusTypeCode<TVectorType>::value;
+		param.push_back(ret);
 		GDBusSignatureFiller<TArgs...>::GetSignature(param);
 	}
 };

--- a/TizenFundamentalClasses/inc/TFC/ServiceModel/GDBusEndpoint.h
+++ b/TizenFundamentalClasses/inc/TFC/ServiceModel/GDBusEndpoint.h
@@ -521,6 +521,12 @@ struct GDBusSignatureFiller<std::vector<TVectorType>, TArgs...>
 	}
 };
 
+template<typename TCurrent, typename... TArgs>
+struct GDBusSignatureFiller<TCurrent const&, TArgs...> : GDBusSignatureFiller<TCurrent, TArgs...>
+{
+
+};
+
 template<>
 struct GDBusSignatureFiller<>
 {

--- a/TizenFundamentalClasses/src/Components/ContextMenu.cpp
+++ b/TizenFundamentalClasses/src/Components/ContextMenu.cpp
@@ -160,6 +160,10 @@ void TFC::Components::ContextMenu::HideMenu()
 	BackButtonHandler::Release();
 }
 
+bool TFC::Components::ContextMenu::IsShow() {
+	return this->menuShown;
+}
+
 bool TFC::Components::ContextMenu::BackButtonClicked()
 {
 	elm_ctxpopup_dismiss(this->contextMenu);

--- a/TizenFundamentalClasses/src/Components/Field.cpp
+++ b/TizenFundamentalClasses/src/Components/Field.cpp
@@ -213,3 +213,14 @@ const std::string& TFC::Components::Field::GetGuideText() const
 
 	return this->guideText;
 }
+
+void TFC::Components::Field::SetCharLimit(const int& limit)
+{
+	limit_size.max_char_count = limit;
+	elm_entry_markup_filter_append(field, elm_entry_filter_limit_size, &limit_size);
+}
+
+int TFC::Components::Field::GetCharLimit() const
+{
+	return limit_size.max_char_count;
+}

--- a/TizenFundamentalClasses/src/Components/GenericList.cpp
+++ b/TizenFundamentalClasses/src/Components/GenericList.cpp
@@ -229,6 +229,7 @@ void TFC::Components::GenericList::SetDataSource(Adapter* newAdapter)
 	// Assign new adapter
 	this->dataSource = newAdapter;
 	firstRealize = true;
+	realBottom = nullptr;
 
 	// Append all existing item in adapter
 	auto& all = dataSource->GetAll();

--- a/TizenFundamentalClasses/src/Components/GenericList.cpp
+++ b/TizenFundamentalClasses/src/Components/GenericList.cpp
@@ -187,8 +187,11 @@ TFC::Components::GenericList::~GenericList()
 	evas_object_smart_callback_del(genlist, "unrealized", EFL::EvasSmartEventHandler);
 	*/
 
-	this->dataSource->eventItemAdd -= EventHandler(GenericList::OnItemAdd);
-	this->dataSource->eventItemRemove -= EventHandler(GenericList::OnItemRemove);
+	if(dataSource)
+	{
+		this->dataSource->eventItemAdd -= EventHandler(GenericList::OnItemAdd);
+		this->dataSource->eventItemRemove -= EventHandler(GenericList::OnItemRemove);
+	}
 }
 
 LIBAPI void TFC::Components::GenericList::ResetScroll(bool animated)

--- a/TizenFundamentalClasses/src/Components/TabbarViewController.cpp
+++ b/TizenFundamentalClasses/src/Components/TabbarViewController.cpp
@@ -240,3 +240,7 @@ void TFC::Components::TabbarViewController::OnTabContentScrolled(
 void TFC::Components::TabbarViewController::OnReload(TFC::ObjectClass* param) {
 	this->tabs[this->currentTab].controller->Reload(param);
 }
+
+int TFC::Components::TabbarViewController::GetCurrentTab() {
+	return this->currentTab;
+}

--- a/TizenFundamentalClasses/src/Infrastructures/ScheduledEvent.cpp
+++ b/TizenFundamentalClasses/src/Infrastructures/ScheduledEvent.cpp
@@ -22,7 +22,17 @@
 
 #include "TFC/Infrastructures/ScheduledEvent.h"
 
+TFC::Infrastructures::ScheduledEvent::ScheduledEvent() :
+	data(nullptr)
+{
+}
+
+void TFC::Infrastructures::ScheduledEvent::SetData(void* data)
+{
+	this->data = data;
+}
+
 void TFC::Infrastructures::ScheduledEvent::Run()
 {
-	eventRunTask(this, nullptr);
+	eventRunTask(this, data);
 }

--- a/TizenFundamentalClasses/src/Infrastructures/ScheduledTask.cpp
+++ b/TizenFundamentalClasses/src/Infrastructures/ScheduledTask.cpp
@@ -96,6 +96,7 @@ LIBAPI void TFC::Infrastructures::ScheduledTask::Cancel() {
 		return;
 
 	ecore_timer_del(this->timer);
+	this->timer = nullptr;
 }
 
 

--- a/TizenFundamentalClasses/src/ServiceModel/GDBusEndpoint.cpp
+++ b/TizenFundamentalClasses/src/ServiceModel/GDBusEndpoint.cpp
@@ -869,9 +869,10 @@ void TFC::ServiceModel::GVariantDeserializer::Deserialize(std::vector<uint8_t>& 
 LIBAPI
 void TFC::ServiceModel::GVariantDeserializer::Deserialize(std::vector<int32_t>& target) {
 	target.clear();
+	dlog_print(DLOG_DEBUG, "TFC-RPC", "Deserialize vector");
 	auto arrVariant = g_variant_iter_next_value(&iter);
 	auto arrIter = g_variant_iter_new(arrVariant);
-	uint8_t value;
+	int32_t value;
 	while (g_variant_iter_next(arrIter, "i", &value)) {
 		target.push_back(value);
 	}
@@ -883,7 +884,7 @@ void TFC::ServiceModel::GVariantDeserializer::Deserialize(std::vector<int64_t>& 
 	target.clear();
 	auto arrVariant = g_variant_iter_next_value(&iter);
 	auto arrIter = g_variant_iter_new(arrVariant);
-	uint8_t value;
+	int64_t value;
 	while (g_variant_iter_next(arrIter, "x", &value)) {
 		target.push_back(value);
 	}

--- a/TizenFundamentalClasses/src/ServiceModel/GDBusEndpoint.cpp
+++ b/TizenFundamentalClasses/src/ServiceModel/GDBusEndpoint.cpp
@@ -933,8 +933,9 @@ void TFC::ServiceModel::GDBusServer::OnConnectionClosedCallback(
 		GDBusConnection* connection, gboolean remote_peer_vanished,
 		GError* error, gpointer user_data) {
 	auto thiz = static_cast<GDBusServer*>(user_data);
-
-	std::remove_if(thiz->connectionList.begin(), thiz->connectionList.end(), [user_data] (GDBusConnection* data) { return data == user_data; });
+	dlog_print(DLOG_DEBUG, "RPC-Test-Connection", "Connection is closed");
+	g_object_unref(connection);
+	std::remove_if(thiz->connectionList.begin(), thiz->connectionList.end(), [connection] (GDBusConnection* data) { return data == connection; });
 }
 
 void TFC::ServiceModel::GDBusServer::EventCaptureHandler(IServerObject<GDBusChannel>* source, IServerObject<GDBusChannel>::EventEmissionInfo const& eventInfo)
@@ -979,7 +980,7 @@ void TFC::ServiceModel::GDBusServer::EventCaptureHandler(IServerObject<GDBusChan
 		dlog_print(DLOG_DEBUG, LOG_TAG, "Emit signal on connection");
 		if(err != nullptr)
 		{
-			dlog_print(DLOG_ERROR, LOG_TAG, "Error on emit signal to connection: %s", err->message);
+			dlog_print(DLOG_ERROR, LOG_TAG, "Error on emit signal to connection: %s (%d)", err->message, err->code);
 			g_error_free(err);
 		}
 	}


### PR DESCRIPTION
- Fix crash in GenericList due to realBottom bug
- Fix invalid comparison in closed connection callback in TFC::ServiceModel::GDBusServer
- Fix missing check for nullptr in destructor of GenericList
- Accepting vector parameter correctly in GDBus
- Fix invalid casting to int8_t for int32_t vector value in TFC::ServiceModel::GDBusDeserializer
- Fix incomplete serialization of vector in TFC::ServiceModel::GDBusDeserializer